### PR TITLE
Use MX records to validate email domains

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests==2.32.3
 pyfiglet==1.0.2
 python-whois==0.9.5
 defusedxml==0.7.1
+dnspython==2.8.0

--- a/utils/email_checker.py
+++ b/utils/email_checker.py
@@ -3,9 +3,10 @@ File used to declare the class used to check if an email exists
 """
 
 import re
-import socket
-import whois
+
+import dns.resolver
 import requests
+import whois
 
 class EmailChecker:
     """
@@ -68,8 +69,8 @@ class EmailChecker:
             if domain in self.known_domains:
                 continue
             try:
-                socket.gethostbyname(domain)
-            except socket.error:
+                dns.resolver.resolve(domain, "MX")
+            except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer, dns.resolver.NoNameservers,):
                 try:
                     res = whois.whois(domain)
                     if res["registrar"] is None:
@@ -80,4 +81,3 @@ class EmailChecker:
                     takeoverable.append([domain, email])
 
         return takeoverable
-    


### PR DESCRIPTION
This should be more precise than the original `socket.gethostbyname()` call since we're dealing with email addresses. I had fewer false positives during my tests with this change. 