### PR TITLE
Fix empty author_email handling for PyPI

### DIFF
--- a/utils/email_checker.py
+++ b/utils/email_checker.py
@@ -20,7 +20,7 @@ class EmailChecker:
                            "cargo":"https://crates.io/api/v1/crates/%s"}
         self.known_domains = ["gmail.com","outlook.com","hotmail.com","protonmail.com"]
 
-    def get_emails(self):
+    def get_emails(self) -> list[str]:
         """
         Method used to make HTTP requests to recover the email
         """
@@ -31,7 +31,8 @@ class EmailChecker:
                     data = res.json()
                     match self.provider:
                         case "pypi":
-                            return [data.get("info").get("author_email")]
+                            if (info := data.get("info")) and (mail := info.get("author_email")):
+                                return [mail]
                         case "npm":
                             emails = []
                             if data.get("maintainers") is not None:
@@ -45,8 +46,7 @@ class EmailChecker:
                             return emails
             except Exception:
                 return []
-        else:
-            return []
+        return []
 
     def check_email(self):
         """
@@ -80,4 +80,3 @@ class EmailChecker:
                     takeoverable.append([domain, email])
 
         return takeoverable
-    


### PR DESCRIPTION
Some PyPI packages are lacking the `author_email` attribute, resulting in `[None]` and crashes down the line.